### PR TITLE
Added a scenario and specs for error messages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,21 +8,16 @@ class PagesController < ApplicationController
 
   def create
     url = params[:page][:url]
-    begin
-      extracted_page = PageExtractor.extract_page(url)
-    rescue Exception => e
-      @message = e.message
-      respond_to do |format|   
-        format.js { render "invalid" }
-      end
-      return
-    end
-
+    extracted_page = PageExtractor.extract_page(url)
     current_user.pages.create(:url => url, :title => extracted_page.title, :text => extracted_page.text)
-
     job_id = WordScheduler.start(params[:page][:speed].to_i, extracted_page.text.split, params[:page][:color])
-
     session[:job] = job_id
+
+  rescue Exceptions::InvalidURL => e
+    @message = e.message
+    respond_to do |format|   
+      format.js { render "invalid" }
+    end
   end
 
   def pause

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,7 +8,16 @@ class PagesController < ApplicationController
 
   def create
     url = params[:page][:url]
-    extracted_page = PageExtractor.new(url)
+    begin
+      extracted_page = PageExtractor.extract_page(url)
+    rescue Exception => e
+      @message = e.message
+      respond_to do |format|   
+        format.js { render "invalid" }
+      end
+      return
+    end
+
     current_user.pages.create(:url => url, :title => extracted_page.title, :text => extracted_page.text)
 
     job_id = WordScheduler.start(params[:page][:speed].to_i, extracted_page.text.split, params[:page][:color])

--- a/app/views/pages/invalid.js.erb
+++ b/app/views/pages/invalid.js.erb
@@ -1,0 +1,1 @@
+$('#notification').text('<%= escape_javascript @message %>');

--- a/features/reading.feature
+++ b/features/reading.feature
@@ -8,3 +8,8 @@ Feature: Reading
   Scenario:
     When I fill in the form
     Then I should see a message saying the text is being processed
+
+  @javascript
+  Scenario:
+    When I fill in the form with a bad url
+    Then I should see a message saying the url is invalid

--- a/features/reading.feature
+++ b/features/reading.feature
@@ -9,16 +9,16 @@ or unreachable).
     And I am signed in
 
   @javascript
-  Scenario:
+  Scenario: Filling in the form with a valid url
     When I fill in the form with a valid url
     Then I should see a message saying the text is being processed
 
   @javascript
-  Scenario:
+  Scenario: Filling in the form with an invalid url
     When I fill in the form with a bad url
     Then I should see a message saying the url is invalid
 
   @javascript
-  Scenario:
+  Scenario: Filling in the form with an unreachable url
     When I fill in the form with a url that cannot be reached
     Then I should see a message saying the url is unreachable

--- a/features/reading.feature
+++ b/features/reading.feature
@@ -1,8 +1,8 @@
 Feature: Reading
-When a user pastes the URL into the URL field and clicks the "Read!" button,
-a corresponding message should appear saying whether the URL is okay
-and the stream is about to start, or the URL is invalid (inappropriate format
-or unreachable).
+  When a user pastes the URL into the URL field and clicks the "Read!" button,
+  a corresponding message should appear saying whether the URL is okay
+  and the stream is about to start, or the URL is invalid (inappropriate format
+  or unreachable).
 
   Background:
     Given I am on the home page

--- a/features/reading.feature
+++ b/features/reading.feature
@@ -1,4 +1,8 @@
 Feature: Reading
+When a user pastes the URL into the URL field and clicks the "Read!" button,
+a corresponding message should appear saying whether the URL is okay
+and the stream is about to start, or the URL is invalid (inappropriate format
+or unreachable).
 
   Background:
     Given I am on the home page

--- a/features/reading.feature
+++ b/features/reading.feature
@@ -6,10 +6,15 @@ Feature: Reading
 
   @javascript
   Scenario:
-    When I fill in the form
+    When I fill in the form with a valid url
     Then I should see a message saying the text is being processed
 
   @javascript
   Scenario:
     When I fill in the form with a bad url
     Then I should see a message saying the url is invalid
+
+  @javascript
+  Scenario:
+    When I fill in the form with a url that cannot be reached
+    Then I should see a message saying the url is unreachable

--- a/features/step_definitions/reading_steps.rb
+++ b/features/step_definitions/reading_steps.rb
@@ -2,7 +2,7 @@ Given(/^I am on the reading page$/) do
   visit root_path
 end
 
-When(/^I fill in the form$/) do
+When(/^I fill in the form with a valid url$/) do
   fill_in("page_url", :with => "http://www.manrepeller.com/2015/07/dream-job.html")
   select '60 wpm', from: 'page_speed'
   select 'b', from: 'page_color'
@@ -23,3 +23,15 @@ end
 Then(/^I should see a message saying the url is invalid$/) do
   expect(page).to have_content "URL format is not valid"
 end
+
+When(/^I fill in the form with a url that cannot be reached$/) do
+  fill_in("page_url", :with => "https://medium.com/@Storyful/production-company")
+  select '60 wpm', from: 'page_speed'
+  select 'b', from: 'page_color'
+  click_button("Read!")
+end
+
+Then(/^I should see a message saying the url is unreachable$/) do
+  expect(page).to have_content "URL cannot be reached"
+end
+

--- a/features/step_definitions/reading_steps.rb
+++ b/features/step_definitions/reading_steps.rb
@@ -12,3 +12,14 @@ end
 Then(/^I should see a message saying the text is being processed$/) do
   expect(page).to have_content "Your text stream will start in a few moments"
 end
+
+When(/^I fill in the form with a bad url$/) do
+  fill_in("page_url", :with => "nonsense")
+  select '60 wpm', from: 'page_speed'
+  select 'b', from: 'page_color'
+  click_button("Read!")
+end
+
+Then(/^I should see a message saying the url is invalid$/) do
+  expect(page).to have_content "URL format is not valid"
+end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,0 +1,3 @@
+module Exceptions
+  class InvalidURL < StandardError; end
+end

--- a/lib/extracted_page.rb
+++ b/lib/extracted_page.rb
@@ -1,0 +1,17 @@
+class ExtractedPage
+
+  def initialize(url)
+    @doc = Nokogiri::HTML(open(url).read)
+  end
+
+  def text
+    @doc.xpath('//h1 | //p').reduce("") do |text, node|
+      text = text + " " + node.text
+    end
+  end
+
+  def title
+    @doc.xpath('/html/head/title').text
+  end
+
+end

--- a/lib/page_extractor.rb
+++ b/lib/page_extractor.rb
@@ -3,43 +3,15 @@ require 'open-uri'
 class PageExtractor
 
   def self.extract_page(url)
-    if valid_format_url(url)
-      if reachable_url(url)
-        self.new(url)
+    if UrlValidator.valid_format?(url)
+      if UrlValidator.reachable?(url)
+        page = ExtractedPage.new(url)
       else
-        raise "URL cannot be reached"
+        raise Exceptions::InvalidURL, "URL cannot be reached"
       end
     else
-      raise "URL format is not valid"
+      raise Exceptions::InvalidURL, "URL format is not valid"
     end
-  end
-
-  def initialize(url)
-    @doc = Nokogiri::HTML(open(url).read)
-  end
-
-  def text
-    @doc.xpath('//h1 | //p').reduce("") do |text, node|
-      text = text + " " + node.text
-    end
-  end
-
-  def title
-    @doc.xpath('/html/head/title').text
-  end
-
-  def self.valid_format_url(url)
-    uri = URI.parse(url)
-    uri.kind_of?(URI::HTTP)
-  rescue URI::Error
-    false
-  end
-
-  def self.reachable_url(url)
-    res = RestClient.head(url)
-    res.code == 200
-  rescue RestClient::Exception
-    false
   end
 
 end

--- a/lib/page_extractor.rb
+++ b/lib/page_extractor.rb
@@ -3,15 +3,10 @@ require 'open-uri'
 class PageExtractor
 
   def self.extract_page(url)
-    if UrlValidator.valid_format?(url)
-      if UrlValidator.reachable?(url)
-        page = ExtractedPage.new(url)
-      else
-        raise Exceptions::InvalidURL, "URL cannot be reached"
-      end
-    else
-      raise Exceptions::InvalidURL, "URL format is not valid"
-    end
+    raise Exceptions::InvalidURL, "URL format is not valid" unless UrlValidator.valid_format?(url)
+    raise Exceptions::InvalidURL, "URL cannot be reached" unless UrlValidator.reachable?(url)
+
+    page = ExtractedPage.new(url)
   end
 
 end

--- a/lib/page_extractor.rb
+++ b/lib/page_extractor.rb
@@ -2,6 +2,18 @@ require 'open-uri'
 
 class PageExtractor
 
+  def self.extract_page(url)
+    if valid_format_url(url)
+      if reachable_url(url)
+        self.new(url)
+      else
+        raise "URL cannot be reached"
+      end
+    else
+      raise "URL format is not valid"
+    end
+  end
+
   def initialize(url)
     @doc = Nokogiri::HTML(open(url).read)
   end
@@ -14,6 +26,20 @@ class PageExtractor
 
   def title
     @doc.xpath('/html/head/title').text
+  end
+
+  def self.valid_format_url(url)
+    uri = URI.parse(url)
+    uri.kind_of?(URI::HTTP)
+  rescue URI::Error
+    false
+  end
+
+  def self.reachable_url(url)
+    res = RestClient.head(url)
+    res.code == 200
+  rescue RestClient::Exception
+    false
   end
 
 end

--- a/lib/url_validator.rb
+++ b/lib/url_validator.rb
@@ -1,0 +1,17 @@
+class UrlValidator
+
+  def self.valid_format?(url)
+    uri = URI.parse(url)
+    uri.kind_of?(URI::HTTP)
+  rescue URI::Error
+    false
+  end
+
+  def self.reachable?(url)
+    res = RestClient.head(url)
+    res.code == 200
+  rescue RestClient::Exception
+    false
+  end
+
+end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PagesController, :type => :controller do
 
     before do
       allow(controller).to receive(:current_user).and_return(user)
-      allow(PageExtractor).to receive(:new).and_return(page)
+      allow(PageExtractor).to receive(:extract_page).and_return(page)
       allow(page).to receive_message_chain(:text, :split)
       allow(user).to receive_message_chain(:pages, :create).and_return(true)
       allow(WordScheduler).to receive(:start).and_return("123")
@@ -19,7 +19,7 @@ RSpec.describe PagesController, :type => :controller do
     end
 
     it "extracts the text from the page" do
-      expect(PageExtractor).to receive(:new).and_return(page)
+      expect(PageExtractor).to receive(:extract_page).and_return(page)
       do_create
     end
 

--- a/spec/lib/extracted_page_spec.rb
+++ b/spec/lib/extracted_page_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "Extracted Page" do
+
+  before :each do
+    @page = ExtractedPage.new(File.join(Rails.root, "spec/lib/example_pages/example.html"))
+  end
+
+  describe "#text" do
+    it "returns text from p and h1 HTML elements" do
+      expect(@page.text).to include("It’s okay to be angry and to be kind of dark")
+    end
+  end
+
+  describe "#title" do
+    it "returns the title from the web page" do
+      expect(@page.title).to include("Stop Trying To Inspire Me")
+    end
+  end
+
+end

--- a/spec/lib/page_extractor_spec.rb
+++ b/spec/lib/page_extractor_spec.rb
@@ -18,4 +18,64 @@ RSpec.describe "Page Extractor" do
     end
   end
 
+  describe "#valid_format_url" do
+    let(:uri) { double("uri") }
+
+    before do
+      allow(URI).to receive(:parse).with("some_url") { uri }
+    end
+
+    context "url is valid" do
+      before do
+        allow(uri).to receive(:kind_of?).and_return(true)
+      end
+
+      it "returns true" do
+        expect(PageExtractor).to receive(:valid_format_url).and_return(true)
+        PageExtractor.valid_format_url("some_url")
+      end
+    end
+
+    context "url is not valid" do
+      before do
+        allow(uri).to receive(:kind_of?).and_return(false)
+      end
+      it "returns false" do
+        expect(PageExtractor).to receive(:valid_format_url).and_return(false)
+        PageExtractor.valid_format_url("some_url")
+      end
+    end
+  end
+
+  describe "#reachable_url" do
+    let(:res) { double("res") }
+
+    before do
+      allow(RestClient).to receive(:head).with("some_url") { res }
+    end
+
+    context "url can be reached" do
+      before do
+        allow(res).to receive(:code) { 200 }
+      end
+
+      it "returns true" do
+        expect(PageExtractor).to receive(:reachable_url).and_return(true)
+        PageExtractor.reachable_url("some_url")
+      end
+    end
+
+    context "url cannot be reached" do
+      before do
+        allow(res).to receive(:code) { 666 }
+      end
+
+      it "returns false" do
+        expect(PageExtractor).to receive(:reachable_url).and_return(false)
+        PageExtractor.reachable_url("some_url")
+      end
+
+    end
+  end
+
 end

--- a/spec/lib/page_extractor_spec.rb
+++ b/spec/lib/page_extractor_spec.rb
@@ -2,80 +2,58 @@ require "rails_helper"
 
 RSpec.describe "Page Extractor" do
 
-  before :each do
-    @page = PageExtractor.new(File.join(Rails.root, "spec/lib/example_pages/example.html"))
+  def valid_format
+    allow(UrlValidator).to receive(:valid_format?).and_return(true)
   end
 
-  describe "#text" do
-    it "returns text from p and h1 HTML elements" do
-      expect(@page.text).to include("It’s okay to be angry and to be kind of dark")
-    end
+  def reachable_url
+    allow(UrlValidator).to receive(:reachable?).and_return(true)
   end
 
-  describe "#title" do
-    it "returns the title from the web page" do
-      expect(@page.title).to include("Stop Trying To Inspire Me")
-    end
+  def invalid_format
+    allow(UrlValidator).to receive(:valid_format?).and_return(false)
   end
 
-  describe "#valid_format_url" do
-    let(:uri) { double("uri") }
+  def unreachable_url
+    allow(UrlValidator).to receive(:reachable?).and_return(false)
+  end
 
-    before do
-      allow(URI).to receive(:parse).with("some_url") { uri }
-    end
+  describe "#extract_page" do
 
-    context "url is valid" do
+    let(:page) { double(ExtractedPage) }
+
+    context "valid url" do
       before do
-        allow(uri).to receive(:kind_of?).and_return(true)
+        valid_format
+        reachable_url
+        allow(ExtractedPage).to receive(:new).and_return(page)
       end
 
-      it "returns true" do
-        expect(PageExtractor).to receive(:valid_format_url).and_return(true)
-        PageExtractor.valid_format_url("some_url")
+      it "returns extracted page" do
+        PageExtractor.extract_page("some_url")
+        expect(page).to_not be_nil
       end
     end
 
-    context "url is not valid" do
+    context "invalid url format" do
       before do
-        allow(uri).to receive(:kind_of?).and_return(false)
+        invalid_format
       end
-      it "returns false" do
-        expect(PageExtractor).to receive(:valid_format_url).and_return(false)
-        PageExtractor.valid_format_url("some_url")
+
+      it "raises URL exception" do
+        expect { PageExtractor.extract_page("some_url") }.to raise_error(Exceptions::InvalidURL, "URL format is not valid")
+      end
+    end
+
+    context "url unreachable" do
+      before do
+        valid_format
+        unreachable_url
+      end
+
+      it "raises URL exception" do
+        expect { PageExtractor.extract_page("some_url") }.to raise_error(Exceptions::InvalidURL, "URL cannot be reached")
       end
     end
   end
-
-  describe "#reachable_url" do
-    let(:res) { double("res") }
-
-    before do
-      allow(RestClient).to receive(:head).with("some_url") { res }
-    end
-
-    context "url can be reached" do
-      before do
-        allow(res).to receive(:code) { 200 }
-      end
-
-      it "returns true" do
-        expect(PageExtractor).to receive(:reachable_url).and_return(true)
-        PageExtractor.reachable_url("some_url")
-      end
-    end
-
-    context "url cannot be reached" do
-      before do
-        allow(res).to receive(:code) { 666 }
-      end
-
-      it "returns false" do
-        expect(PageExtractor).to receive(:reachable_url).and_return(false)
-        PageExtractor.reachable_url("some_url")
-      end
-
-    end
-  end
-
 end

--- a/spec/lib/url_validator_spec.rb
+++ b/spec/lib/url_validator_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe "URL Validator" do
+
+  describe "#valid_format?" do
+
+    let(:uri) { double("uri") }
+
+    context "url is valid" do
+
+      before do
+        allow(URI).to receive(:parse).with("url") { uri }
+        allow(uri).to receive(:kind_of?).and_return(true)
+      end
+
+      it "returns true" do
+        expect(UrlValidator).to receive(:valid_format?).with("url").and_return(true)
+        UrlValidator.valid_format?("url")
+      end
+
+    end
+
+    context "url is invalid" do
+
+      it "returns false" do
+        expect(UrlValidator).to receive(:valid_format?).and_return(false)
+        UrlValidator.valid_format?("url")
+      end
+
+    end
+
+  end
+
+  describe "#reachable?" do
+
+    let(:res) { double("res") }
+
+    context "url is reachable" do
+
+      before do
+        allow(RestClient).to receive(:head).with("some_url") { res }
+        allow(res).to receive(:code).and_return(200)
+      end
+
+      it "returns true" do
+        expect(UrlValidator).to receive(:reachable?).with("some_url").and_return(true)
+        UrlValidator.reachable?("some_url")
+      end
+
+    end
+
+    context "url is not reachable" do
+
+      it "returns false" do
+        expect(UrlValidator).to receive(:reachable?).with("some_url").and_return(false)
+        UrlValidator.reachable?("some_url")
+      end
+
+    end
+    
+  end
+  
+end


### PR DESCRIPTION
Page Extractor now validates the URL format and availability. The user should see a message if a bad URL is pasted into the URL field.
